### PR TITLE
商品情報編集ページ遷移の実装の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,11 @@ class ItemsController < ApplicationController
 
   def edit
     redirect_to action: :index unless current_user.id == @item.user_id
+
+    if @item.purchase != nil && current_user.id == @item.user_id
+      redirect_to root_path
+    end
+
   end
 
   def update


### PR DESCRIPTION
# What
商品情報編集ページ遷移の実装の修正

# Why
ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移するように実装する為